### PR TITLE
Show currency names

### DIFF
--- a/bitfinex.lua
+++ b/bitfinex.lua
@@ -105,7 +105,7 @@ function RefreshAccount(account, since)
 
     if prices[currencyName] ~= nil and shares > 0 then
       s[#s+1] = {
-        name = currencyName,
+        name = currencyNames[currencyName] .. " (" .. currencyName .. ")",
         market = market,
         currency = nil,
         quantity = shares,


### PR DESCRIPTION
Show nice currency names in asset overview instead of the ticker symbols

e.g.

Bitcoin (BTC)
instead of only
BTC